### PR TITLE
feat: add GetWithLocale API and strengthen error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 -   [Translations](#translations)
     -   [Passing Data to Translation](#passing-data-to-translation)
     -   [Direct Formatting](#direct-formatting)
+    -   [Getting Source Locale](#getting-source-locale)
 -   [Pluralization](#pluralization)
 -   [Text-based Translations](#text-based-translations)
     -   [Disambiguation by context](#disambiguation-by-context)
@@ -471,7 +472,96 @@ en-GB -> en-US -> ja-JP
 
 Recursive fallback is also supported. If `zh-Hans` has a `zh` fallback, and `zh` has a `zh-Hant` fallback, `zh-Hans` will have either `zh` and `zh-Hant` fallbacks.
 
-Fallback only works if the translation exists in default language.
+**Important:** Fallback chains only apply to keys that exist in the default locale. If a key exists in a fallback locale but not in the default locale, it will not be automatically propagated to other locales. Ensure your default locale contains all possible translation keys.
+
+&nbsp;
+
+### Getting Source Locale
+
+When you need to know which locale provided the translation (especially useful for debugging or analytics), use the `GetWithLocale`, `GetXWithLocale`, or `GetfWithLocale` methods. These methods return the translated text, the source locale, and an error indicating whether the translation was found.
+
+```go
+text, locale, err := localizer.GetWithLocale("hello")
+if errors.Is(err, i18n.ErrTranslationNotFound) {
+    // Translation was not found in loaded translations
+    // `text` contains the fallback (key itself)
+    // `locale` is the default locale where runtime fallback was created
+} else if err != nil {
+    // Handle other errors (e.g., MessageFormat compilation failed)
+} else {
+    // Translation found successfully
+    fmt.Printf("Translated by %s: %s\n", locale, text)
+}
+```
+
+**Error Types:**
+
+| Error | Description |
+|-------|-------------|
+| `i18n.ErrTranslationNotFound` | Translation not found in loaded translations. A runtime fallback was used (key as text). |
+| `i18n.ErrMessageFormatCompilation` | MessageFormat template compilation failed. The raw text is returned without formatting. |
+
+**Notes on `GetfWithLocale`:**
+
+When using `GetfWithLocale`, if the translation is not found, the key itself is returned **without** applying `fmt.Sprintf` formatting. This prevents `%!EXTRA` errors when arguments are provided but the key doesn't exist:
+
+```go
+// Key exists: formatting is applied
+text, locale, err := localizer.GetfWithLocale("greeting", "Alice")
+// text: "Hello, Alice!", locale: "en", err: nil
+
+// Key missing: returns key as-is without formatting
+text, locale, err := localizer.GetfWithLocale("missing_key", "Alice")
+// text: "missing_key" (NOT "missing_key%!(EXTRA string=Alice)"), locale: "en", err: ErrTranslationNotFound
+```
+
+These errors can be checked with `errors.Is()`:
+
+```go
+// Check if translation was not found
+if errors.Is(err, i18n.ErrTranslationNotFound) {
+    // Handle missing translation
+}
+
+// Check for MessageFormat compilation issues
+if errors.Is(err, i18n.ErrMessageFormatCompilation) {
+    // Handle compilation error
+}
+```
+
+**Complete Example:**
+
+```go
+bundle := i18n.NewBundle(
+    i18n.WithDefaultLocale("en"),
+    i18n.WithLocales("en", "zh-Hans"),
+)
+
+bundle.LoadMessages(map[string]map[string]string{
+    "en":      {"hello": "Hello"},
+    "zh-Hans": {"hello": "你好"},
+})
+
+localizer := bundle.NewLocalizer("zh-Hans")
+
+// Successful lookup
+text, locale, err := localizer.GetWithLocale("hello")
+// text: "你好", locale: "zh-Hans", err: nil
+
+// Missing translation (fallback to default locale)
+text, locale, err := localizer.GetWithLocale("goodbye")
+// text: "goodbye", locale: "en", err: ErrTranslationNotFound
+
+// With variables
+text, locale, err := localizer.GetWithLocale("hello", i18n.Vars{"name": "World"})
+// text: "你好", locale: "zh-Hans", err: nil
+
+// With context
+text, locale, err := localizer.GetXWithLocale("Post", "verb")
+
+// With sprintf formatting
+text, locale, err := localizer.GetfWithLocale("greeting", "Alice")
+```
 
 &nbsp;
 

--- a/examples/source_locale/main.go
+++ b/examples/source_locale/main.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/kaptinlin/go-i18n"
+)
+
+func main() {
+	bundle := i18n.NewBundle(
+		i18n.WithDefaultLocale("en"),
+		i18n.WithLocales("en", "zh-Hans"),
+	)
+
+	// Load translations
+	bundle.LoadMessages(map[string]map[string]string{
+		"en": {
+			"hello":   "Hello, {name}!",
+			"goodbye": "Goodbye, {name}!",
+		},
+		"zh-Hans": {
+			"hello": "你好，{name}！",
+			// Note: "goodbye" is not translated in zh-Hans
+		},
+	})
+
+	localizer := bundle.NewLocalizer("zh-Hans")
+
+	fmt.Println("=== GetWithLocale Examples ===")
+
+	// Example 1: Successful translation lookup
+	text, locale, err := localizer.GetWithLocale("hello", i18n.Vars{"name": "World"})
+	printResult("hello", text, locale, err)
+
+	// Example 2: Missing translation (falls back to default locale)
+	text, locale, err = localizer.GetWithLocale("goodbye", i18n.Vars{"name": "World"})
+	printResult("goodbye", text, locale, err)
+
+	// Example 3: Translation not found anywhere
+	text, locale, err = localizer.GetWithLocale("unknown_key")
+	printResult("unknown_key", text, locale, err)
+
+	fmt.Println("\n=== GetXWithLocale Examples ===")
+
+	// Add context-based translations
+	bundle.LoadMessages(map[string]map[string]string{
+		"zh-Hans": {
+			"Post <verb>": "发布文章",
+			"Post <noun>": "文章",
+		},
+	})
+
+	text, locale, err = localizer.GetXWithLocale("Post", "verb")
+	printResult("Post (verb)", text, locale, err)
+
+	text, locale, err = localizer.GetXWithLocale("Post", "noun")
+	printResult("Post (noun)", text, locale, err)
+
+	fmt.Println("\n=== GetfWithLocale Examples ===")
+
+	// Note: GetfWithLocale uses fmt.Sprintf-style formatting (%s, %d, etc.)
+	// This is different from GetWithLocale which uses MessageFormat variables ({name})
+
+	// First, let's load a sprintf-style translation
+	bundle.LoadMessages(map[string]map[string]string{
+		"zh-Hans": {
+			"greeting": "你好，%s！",
+		},
+	})
+
+	text, locale, err = localizer.GetfWithLocale("greeting", "Alice")
+	printResult("greeting (sprintf)", text, locale, err)
+
+	// Missing key with GetfWithLocale - returns key as-is without formatting
+	// to avoid "%!EXTRA" errors from fmt.Sprintf
+	text, locale, err = localizer.GetfWithLocale("missing_key", "Alice")
+	printResult("missing_key (sprintf)", text, locale, err)
+}
+
+func printResult(key, text, locale string, err error) {
+	fmt.Printf("Key: %q\n", key)
+	fmt.Printf("  Text:   %q\n", text)
+	fmt.Printf("  Locale: %q\n", locale)
+
+	if err == nil {
+		fmt.Println("  Error:  none")
+	} else {
+		if errors.Is(err, i18n.ErrTranslationNotFound) {
+			fmt.Println("  Error:  ErrTranslationNotFound")
+		}
+		if errors.Is(err, i18n.ErrMessageFormatCompilation) {
+			fmt.Println("  Error:  ErrMessageFormatCompilation")
+		}
+	}
+	fmt.Println()
+}

--- a/examples/source_locale/main.go
+++ b/examples/source_locale/main.go
@@ -14,7 +14,7 @@ func main() {
 	)
 
 	// Load translations
-	bundle.LoadMessages(map[string]map[string]string{
+	err := bundle.LoadMessages(map[string]map[string]string{
 		"en": {
 			"hello":   "Hello, {name}!",
 			"goodbye": "Goodbye, {name}!",
@@ -24,6 +24,9 @@ func main() {
 			// Note: "goodbye" is not translated in zh-Hans
 		},
 	})
+	if err != nil {
+		panic(err)
+	}
 
 	localizer := bundle.NewLocalizer("zh-Hans")
 
@@ -44,12 +47,15 @@ func main() {
 	fmt.Println("\n=== GetXWithLocale Examples ===")
 
 	// Add context-based translations
-	bundle.LoadMessages(map[string]map[string]string{
+	err = bundle.LoadMessages(map[string]map[string]string{
 		"zh-Hans": {
 			"Post <verb>": "发布文章",
 			"Post <noun>": "文章",
 		},
 	})
+	if err != nil {
+		panic(err)
+	}
 
 	text, locale, err = localizer.GetXWithLocale("Post", "verb")
 	printResult("Post (verb)", text, locale, err)
@@ -63,11 +69,14 @@ func main() {
 	// This is different from GetWithLocale which uses MessageFormat variables ({name})
 
 	// First, let's load a sprintf-style translation
-	bundle.LoadMessages(map[string]map[string]string{
+	err = bundle.LoadMessages(map[string]map[string]string{
 		"zh-Hans": {
 			"greeting": "你好，%s！",
 		},
 	})
+	if err != nil {
+		panic(err)
+	}
 
 	text, locale, err = localizer.GetfWithLocale("greeting", "Alice")
 	printResult("greeting (sprintf)", text, locale, err)

--- a/i18n.go
+++ b/i18n.go
@@ -1,6 +1,8 @@
 package i18n
 
 import (
+	"errors"
+	"fmt"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -8,6 +10,13 @@ import (
 	"github.com/go-json-experiment/json"
 	mf "github.com/kaptinlin/messageformat-go/v1"
 	"golang.org/x/text/language"
+)
+
+// Errors related to translation loading and compilation.
+var (
+	// ErrMessageFormatCompilation indicates that MessageFormat template compilation failed.
+	// The translation text is returned as-is without formatting capabilities.
+	ErrMessageFormatCompilation = errors.New("messageformat compilation failed")
 )
 
 // Unmarshaler unmarshals translation files. Common implementations include
@@ -206,8 +215,8 @@ func trimContext(v string) string {
 }
 
 // parseTranslation compiles a translation text into a parsedTranslation.
-// If MessageFormat compilation fails, it returns the translation with the raw
-// text as a graceful fallback.
+// Returns [ErrMessageFormatCompilation] if MessageFormat compilation fails,
+// along with a parsedTranslation that contains the raw text (usable without formatting).
 func (i *I18n) parseTranslation(locale, name, text string) (*parsedTranslation, error) {
 	pt := &parsedTranslation{
 		name:   name,
@@ -219,12 +228,12 @@ func (i *I18n) parseTranslation(locale, name, text string) (*parsedTranslation, 
 
 	formatter, err := mf.New(base.String(), i.mfOptions)
 	if err != nil {
-		return pt, nil //nolint:nilerr // Graceful fallback on compilation error
+		return pt, fmt.Errorf("%w: create formatter: %w", ErrMessageFormatCompilation, err)
 	}
 
 	compiled, err := formatter.Compile(text)
 	if err != nil {
-		return pt, nil //nolint:nilerr // Graceful fallback on compilation error
+		return pt, fmt.Errorf("%w: %w", ErrMessageFormatCompilation, err)
 	}
 
 	pt.format = compiled

--- a/i18n_test.go
+++ b/i18n_test.go
@@ -215,3 +215,72 @@ func TestCircularFallback(t *testing.T) {
 	// Should fall through to default locale without hanging.
 	assert.Equal("Hello", localizer.Get("hello"))
 }
+
+func TestParseTranslationSuccess(t *testing.T) {
+	assert := assert.New(t)
+	bundle := NewBundle(WithDefaultLocale("en"))
+
+	pt, err := bundle.parseTranslation("en", "test_key", "Hello, {name}!")
+	assert.NoError(err)
+	assert.NotNil(pt)
+	assert.Equal("test_key", pt.name)
+	assert.Equal("en", pt.locale)
+	assert.Equal("Hello, {name}!", pt.text)
+	assert.NotNil(pt.format) // MessageFormat should be compiled successfully
+}
+
+func TestParseTranslationInvalidMessageFormat(t *testing.T) {
+	assert := assert.New(t)
+	bundle := NewBundle(WithDefaultLocale("en"))
+
+	// Invalid MessageFormat syntax (unclosed brace)
+	pt, err := bundle.parseTranslation("en", "test_key", "Hello, {name")
+	assert.ErrorIs(err, ErrMessageFormatCompilation)
+	assert.NotNil(pt) // Returns pt with raw text even on error
+	assert.Equal("Hello, {name", pt.text)
+	assert.Nil(pt.format) // No compiled format available
+}
+
+func TestParseTranslationEmptyMessageFormat(t *testing.T) {
+	assert := assert.New(t)
+	bundle := NewBundle(WithDefaultLocale("en"))
+
+	// Empty message should compile successfully (just no formatting)
+	pt, err := bundle.parseTranslation("en", "test_key", "")
+	assert.NoError(err)
+	assert.NotNil(pt)
+	assert.Equal("", pt.text)
+}
+
+func TestParseTranslationComplexMessageFormat(t *testing.T) {
+	assert := assert.New(t)
+	bundle := NewBundle(WithDefaultLocale("en"))
+
+	// Complex MessageFormat with plural
+	pt, err := bundle.parseTranslation("en", "test_key", "{count, plural, =0 {none} one {# item} other {# items}}")
+	assert.NoError(err)
+	assert.NotNil(pt)
+	assert.NotNil(pt.format)
+}
+
+func TestErrMessageFormatCompilationWrapping(t *testing.T) {
+	assert := assert.New(t)
+	bundle := NewBundle(
+		WithDefaultLocale("en"),
+		WithLocales("en", "zh-Hans"),
+	)
+	err := bundle.LoadMessages(map[string]map[string]string{
+		"en": {"valid": "Hello"},
+	})
+	assert.NoError(err)
+
+	localizer := bundle.NewLocalizer("zh-Hans")
+
+	// Trigger runtime fallback with invalid MessageFormat syntax
+	// The key itself will be used as text and parsed as MessageFormat
+	text, locale, err := localizer.GetWithLocale("{invalid syntax")
+	assert.Equal("{invalid syntax", text)
+	assert.Equal("en", locale)
+	assert.ErrorIs(err, ErrTranslationNotFound)
+	assert.ErrorIs(err, ErrMessageFormatCompilation) // Should be wrapped
+}

--- a/localizer.go
+++ b/localizer.go
@@ -1,11 +1,17 @@
 package i18n
 
 import (
+	"errors"
 	"fmt"
 
 	mf "github.com/kaptinlin/messageformat-go/v1"
 	"golang.org/x/text/language"
 )
+
+// ErrTranslationNotFound indicates that a translation was not found in any
+// of the loaded translations for the requested locale or its fallback chain.
+// A runtime fallback translation is created using the key itself as the text.
+var ErrTranslationNotFound = errors.New("translation not found")
 
 // Localizer provides translation methods for a specific locale. Create one
 // via [I18n.NewLocalizer].
@@ -22,10 +28,7 @@ func (l *Localizer) Locale() string {
 // Get returns the translation for name with optional MessageFormat variables.
 // Returns name as fallback if no translation is found.
 func (l *Localizer) Get(name string, data ...Vars) string {
-	pt, err := l.lookup(name)
-	if err != nil {
-		return name
-	}
+	pt, _ := l.lookup(name)
 	return l.localize(pt, data...)
 }
 
@@ -36,33 +39,67 @@ func (l *Localizer) GetX(name, context string, data ...Vars) string {
 	return l.Get(name+" <"+context+">", data...)
 }
 
+// GetWithLocale returns the translation for name with optional MessageFormat variables,
+// along with the source locale where the translation was found.
+// If the translation is not found in the loaded translations, it returns [ErrTranslationNotFound]
+// and the source locale will be the default locale where the runtime fallback was created.
+func (l *Localizer) GetWithLocale(name string, data ...Vars) (text string, sourceLocale string, err error) {
+	pt, err := l.lookup(name)
+	return l.localize(pt, data...), pt.locale, err
+}
+
+// GetXWithLocale returns the translation for name disambiguated by context,
+// along with the source locale where the translation was found.
+// If the translation is not found, it returns [ErrTranslationNotFound].
+// The context is appended as " <context>" to form the lookup key.
+// For example, GetXWithLocale("Post", "verb") looks up "Post <verb>".
+func (l *Localizer) GetXWithLocale(name, context string, data ...Vars) (text string, sourceLocale string, err error) {
+	return l.GetWithLocale(name+" <"+context+">", data...)
+}
+
 // Getf returns the translation for name formatted with fmt.Sprintf.
 // Uses name as the format string if no translation is found.
 func (l *Localizer) Getf(name string, args ...any) string {
+	pt, _ := l.lookup(name)
+	return fmt.Sprintf(l.localize(pt), args...)
+}
+
+// GetfWithLocale returns the translation for name formatted with fmt.Sprintf,
+// along with the source locale where the translation was found.
+// If the translation is not found, it returns [ErrTranslationNotFound].
+// Note: If the translation is not found, the returned text will be the key itself
+// (not formatted) to avoid fmt.Sprintf errors with missing arguments.
+func (l *Localizer) GetfWithLocale(name string, args ...any) (text string, sourceLocale string, err error) {
 	pt, err := l.lookup(name)
 	if err != nil {
-		return name
+		// Return the key as-is without formatting to avoid %!EXTRA errors
+		return name, pt.locale, err
 	}
-	return fmt.Sprintf(l.localize(pt), args...)
+	return fmt.Sprintf(l.localize(pt), args...), pt.locale, nil
 }
 
 // lookup resolves the translation for name by checking the locale's
 // pre-parsed translations first, then falling back to runtime-parsed
 // translations from the default locale. If no translation exists, it
 // creates a new runtime translation using the name as the text.
+//
+// Returns [ErrTranslationNotFound] if the translation is not found in loaded
+// translations (runtime fallback was used). May also wrap [ErrMessageFormatCompilation]
+// if MessageFormat compilation failed during runtime fallback creation.
 func (l *Localizer) lookup(name string) (*parsedTranslation, error) {
 	if pt, ok := l.bundle.parsedTranslations[l.locale][name]; ok {
 		return pt, nil
 	}
 	if pt, ok := l.bundle.runtimeParsedTranslations[name]; ok {
-		return pt, nil
+		return pt, ErrTranslationNotFound
 	}
 	pt, err := l.bundle.parseTranslation(l.bundle.defaultLocale, name, trimContext(name))
-	if err != nil {
-		return nil, err
-	}
 	l.bundle.runtimeParsedTranslations[name] = pt
-	return pt, nil
+	if err != nil {
+		// MessageFormat compilation failed, but we still have the raw text
+		return pt, fmt.Errorf("%w: %w", ErrTranslationNotFound, err)
+	}
+	return pt, ErrTranslationNotFound
 }
 
 // localize formats a parsed translation with the given variables.

--- a/localizer_test.go
+++ b/localizer_test.go
@@ -428,3 +428,151 @@ func TestGetRuntimeParsedTranslationCache(t *testing.T) {
 	// Second call: should hit runtimeParsedTranslations cache.
 	assert.Equal("Goodbye", loc.Get("Goodbye"))
 }
+
+func TestGetWithLocale(t *testing.T) {
+	assert := assert.New(t)
+	bundle := NewBundle(
+		WithDefaultLocale("en"),
+		WithLocales("en", "zh-Hans"),
+	)
+	err := bundle.LoadMessages(map[string]map[string]string{
+		"en":      {"hello": "Hello", "bye": "Goodbye"},
+		"zh-Hans": {"hello": "你好"},
+	})
+	assert.NoError(err)
+
+	loc := bundle.NewLocalizer("zh-Hans")
+
+	// Test getting translation from current locale
+	text, sourceLocale, err := loc.GetWithLocale("hello")
+	assert.Equal("你好", text)
+	assert.Equal("zh-Hans", sourceLocale)
+	assert.NoError(err)
+
+	// Test fallback to default locale
+	text, sourceLocale, err = loc.GetWithLocale("bye")
+	assert.Equal("Goodbye", text)
+	assert.Equal("en", sourceLocale)
+	assert.NoError(err)
+
+	// Test missing key returns key as text with default locale and ErrTranslationNotFound
+	text, sourceLocale, err = loc.GetWithLocale("nonexistent")
+	assert.Equal("nonexistent", text)
+	assert.Equal("en", sourceLocale)
+	assert.ErrorIs(err, ErrTranslationNotFound)
+}
+
+func TestGetXWithLocale(t *testing.T) {
+	assert := assert.New(t)
+	bundle := NewBundle(
+		WithDefaultLocale("en"),
+		WithLocales("en", "zh-Hans"),
+	)
+	err := bundle.LoadMessages(map[string]map[string]string{
+		"en":        {"Post <verb>": "Post", "Post <noun>": "Post"},
+		"zh-Hans":   {"Post <verb>": "发表", "Post <noun>": "帖子"},
+	})
+	assert.NoError(err)
+
+	loc := bundle.NewLocalizer("zh-Hans")
+
+	text, sourceLocale, err := loc.GetXWithLocale("Post", "verb")
+	assert.Equal("发表", text)
+	assert.Equal("zh-Hans", sourceLocale)
+	assert.NoError(err)
+
+	text, sourceLocale, err = loc.GetXWithLocale("Post", "noun")
+	assert.Equal("帖子", text)
+	assert.Equal("zh-Hans", sourceLocale)
+	assert.NoError(err)
+}
+
+func TestGetfWithLocale(t *testing.T) {
+	assert := assert.New(t)
+	bundle := NewBundle(
+		WithDefaultLocale("en"),
+		WithLocales("en", "zh-Hans"),
+	)
+	err := bundle.LoadMessages(map[string]map[string]string{
+		"en":      {"greeting": "Hello, %s!"},
+		"zh-Hans": {"greeting": "你好，%s！"},
+	})
+	assert.NoError(err)
+
+	loc := bundle.NewLocalizer("zh-Hans")
+
+	text, sourceLocale, err := loc.GetfWithLocale("greeting", "Alice")
+	assert.Equal("你好，Alice！", text)
+	assert.Equal("zh-Hans", sourceLocale)
+	assert.NoError(err)
+
+	// Test missing key - returns name as-is with no formatting applied and ErrTranslationNotFound
+	text, sourceLocale, err = loc.GetfWithLocale("nonexistent", "Alice")
+	assert.Equal("nonexistent", text)
+	assert.Equal("en", sourceLocale)
+	assert.ErrorIs(err, ErrTranslationNotFound)
+}
+
+func TestGetWithLocaleFallbackChain(t *testing.T) {
+	assert := assert.New(t)
+	bundle := NewBundle(
+		WithDefaultLocale("en"),
+		WithLocales("en", "zh-Hans", "ja-JP"),
+		WithFallback(map[string][]string{
+			"ja-JP": {"zh-Hans"},
+		}),
+	)
+	// Load translations for all locales
+	// Note: formatFallbacks iterates over defaultLocale (en) keys to fill missing translations
+	err := bundle.LoadMessages(map[string]map[string]string{
+		"en":      {"hello": "Hello", "shared_key": "English"},
+		"zh-Hans": {"hello": "你好", "shared_key": "Chinese"},
+		"ja-JP":   {"hello": "こんにちは"},
+	})
+	assert.NoError(err)
+
+	loc := bundle.NewLocalizer("ja-JP")
+
+	// Test direct hit in ja-JP
+	text, locale, err := loc.GetWithLocale("hello")
+	assert.Equal("こんにちは", text)
+	assert.Equal("ja-JP", locale)
+	assert.NoError(err)
+
+	// Test ja-JP -> zh-Hans fallback (configured in WithFallback)
+	// shared_key is in en (default) and zh-Hans (fallback)
+	// formatFallbacks fills ja-JP from zh-Hans during loading (best fallback)
+	text, locale, err = loc.GetWithLocale("shared_key")
+	assert.Equal("Chinese", text)
+	assert.Equal("zh-Hans", locale)
+	assert.NoError(err)
+}
+
+
+
+func TestGetWithLocaleWithVars(t *testing.T) {
+	assert := assert.New(t)
+	bundle := NewBundle(
+		WithDefaultLocale("en"),
+		WithLocales("en", "zh-Hans"),
+	)
+	err := bundle.LoadMessages(map[string]map[string]string{
+		"en":      {"greeting": "Hello, {name}!"},
+		"zh-Hans": {"greeting": "你好，{name}！"},
+	})
+	assert.NoError(err)
+
+	loc := bundle.NewLocalizer("zh-Hans")
+
+	// With MessageFormat variables
+	text, locale, err := loc.GetWithLocale("greeting", Vars{"name": "World"})
+	assert.Equal("你好，World！", text)
+	assert.Equal("zh-Hans", locale)
+	assert.NoError(err)
+
+	// Fallback with variables
+	text, locale, err = loc.GetWithLocale("unknown", Vars{"name": "Test"})
+	assert.Equal("unknown", text) // Key returned as-is
+	assert.Equal("en", locale)
+	assert.ErrorIs(err, ErrTranslationNotFound)
+}


### PR DESCRIPTION
## Summary

Add GetWithLocale API to return source locale information.

## Changes

- Add `GetWithLocale`, `GetXWithLocale`, `GetfWithLocale` methods
- Add `ErrTranslationNotFound` and `ErrMessageFormatCompilation` errors
- Strengthen `parseTranslation` error handling

Closes #30